### PR TITLE
ESP8266 and ESP32 support

### DIFF
--- a/examples/HelloWorld_ESP/HelloWorld_ESP.ino
+++ b/examples/HelloWorld_ESP/HelloWorld_ESP.ino
@@ -1,0 +1,32 @@
+/** Bare minimum example sketch for MP3 player.
+ *
+ *  Simply plays all tracks in a loop.
+ *
+ * @author James Sleeman,  http://sparks.gogo.co.nz/
+ * @license MIT License
+ * @file
+ */
+ 
+#include <Arduino.h>
+#include <SoftwareSerial.h>
+#include <JQ6500_Serial.h>
+
+// Create the mp3 module object, 
+//   Arduino Pin 8 is connected to TX of the JQ6500
+//   Arduino Pin 9 is connected to one end of a  1k resistor, 
+//     the other end of the 1k resistor is connected to RX of the JQ6500
+//   If your Arduino is 3v3 powered, you can omit the 1k series resistor
+JQ6500_Serial mp3;
+
+void setup() {
+  // Specific to ESP Platform, Tx and Rx pin must be declared in the begin method, instead of during object instanciation.
+  mp3.begin(9600,8,9);
+  mp3.reset();
+  mp3.setVolume(20);
+  mp3.setLoopMode(MP3_LOOP_ALL);
+  mp3.play();  
+}
+
+void loop() {
+  // Do nothing, it's already playing and looping :-)
+}

--- a/src/JQ6500_Serial.h
+++ b/src/JQ6500_Serial.h
@@ -108,9 +108,11 @@ class JQ6500_Serial : public SoftwareSerial
      *
      * and all the other commands :-)
      */
-    
+#if defined(ESP8266) || defined(ESP32)
+    JQ6500_Serial() : SoftwareSerial() { };
+#else
     JQ6500_Serial(short rxPin, short txPin) : SoftwareSerial(rxPin,txPin) { };
-    
+#endif
     /** Start playing the current file.
      */
     


### PR DESCRIPTION
On ESP a new mp3 object must be initialized that way :

JQ6500_Serial mp3;
mp3.begin(speed,txpin,rxpin);

This is due to the underlying SoftwareSerial implementation which is
different on those platform. (https://github.com/plerup/espsoftwareserial)