### PR TITLE
fix syntax error in architectures list

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Library for controlling JQ6500 MP3 Player Devices
 paragraph=Allows complete control of the JQ6500 (JQ6500-28P, JQ6500-16P) Mp3 Player Modules using Software Serial.
 category=Other
 url=https://github.com/sleemanj/JQ6500_Serial
-architectures=avr esp8266 esp32
+architectures=avr,esp8266,esp32
 dot_a_linkage=true


### PR DESCRIPTION
sry for this new very small pull request, shall have test that one before submitting the previous one --'