### PR TITLE
Fix HelloWorld_ESP.ino

### DIFF
--- a/examples/HelloWorld_ESP/HelloWorld_ESP.ino
+++ b/examples/HelloWorld_ESP/HelloWorld_ESP.ino
@@ -19,8 +19,9 @@
 JQ6500_Serial mp3;
 
 void setup() {
-  // Specific to ESP Platform, Tx and Rx pin must be declared in the begin method, instead of during object instanciation.
-  mp3.begin(9600,8,9);
+  // Specific to ESP Platform. Serial Config, TX and RX pins must be declared
+  // in the begin method, instead of during object instanciation.
+  mp3.begin(9600, SWSERIAL_8N1, 8, 9);
   mp3.reset();
   mp3.setVolume(20);
   mp3.setLoopMode(MP3_LOOP_ALL);


### PR DESCRIPTION
Since [version 6.2.0 of SoftwareSerial for ESP8266](https://github.com/plerup/espsoftwareserial/releases/tag/6.2.0) (or earlier, I couldn't pinpoint it), the `begin()` method has four arguments: baud rate, configuration (no. of bits, parity and stop bits), rxPin and txPin. So the right way to configure the audio module is:

```c++
JQ6500_Serial mp3;
// ...
mp3.begin(9600, SWSERIAL_8N1, 8, 9);
```

On the other hand, you could also revert commit d44a5048 and remove the separate example file, since also starting at version  6.2.0 the ESP API is backwards-compatible again with the Arduino version.